### PR TITLE
throws an error when there is no file to load on the Inventory folder

### DIFF
--- a/inventory.js
+++ b/inventory.js
@@ -63,6 +63,11 @@ function inventory(creds){
       return file.unix_timestamp
     }).value()
 
+    if(orderedFiles.length === 0){
+      throw new Error("No File Found");
+
+      return;
+    }
     // get the last item in the sorted array
     var latestFile = _.last(orderedFiles)
 


### PR DESCRIPTION
Holstee is having a problem where sync is no happening because there is no file on Inventory folder to quickly solve this Dave asked me to generate a file report to alert when this happening, I added an thrown error that I can catch to generate this report.
